### PR TITLE
Flag path implemented for encrypt command

### DIFF
--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"program/main/cipher"
@@ -34,23 +33,20 @@ to quickly create a Cobra application.`,
 		// Read encrypted file
 		dat, err := os.ReadFile(args[0])
 		error.Check(err)
-		log.SetFlags(log.LstdFlags | log.Llongfile)
-		log.Println(": inputted file working")
 
 		key := "this_must_be_of_32_byte_length!!"
 		decryptedString := cipher.DecryptFile(key, string(dat))
 
 		// Creating a new file to store decrytped text
-		f, err := os.Create("/Users/luka/Desktop/encrypted/message.txt")
+		filePath := "/Users/luka/Desktop/encrypted/dat2"
+		f, err := os.Create(filePath)
 		error.Check(err)
-
-		log.Println("Create file path working")
 
 		defer f.Close()
 
 		text, err := f.WriteString(decryptedString)
 		error.Check(err)
-		fmt.Printf("Wrote %d bytes.\n", text)
+		fmt.Printf("Wrote %d bytes to %s.\n", text, filePath)
 
 		f.Sync()
 	},
@@ -59,13 +55,5 @@ to quickly create a Cobra application.`,
 func init() {
 	rootCmd.AddCommand(decryptCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// decryptCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// decryptCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// Command flags
 }

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -15,14 +15,14 @@ import (
 
 // encryptCmd represents the encrypt command
 var encryptCmd = &cobra.Command{
-	Use:   "encrypt [FILE]",
+	Use:   "encrypt [FILE] --path=[path]",
 	Short: "Encrypting a [FILE] with AES encryption",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Long: `The encrypt command takes in a argumnet for the file to encrypt
+	and a flag command for the path to store the result. The file path flag 
+	must be the full path on you computer. For example:
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	encrypt ~/Desktop/names.txt --path=/Users/luka/Desktop/encrypted/dat2
+	decrypt ~/Desktop/decrypted/message.txt`,
 
 	// Only one number of args
 	Args: cobra.MaximumNArgs(1),
@@ -30,46 +30,33 @@ to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("encrypting")
 
-		// Read the file and check for an error
+		// Get the flag value
+		outputPath := cmd.Flags().Lookup("path").Value.String()
+
+		// dat stores raw bytes of file being read from the command argument args[0]
 		dat, err := os.ReadFile(args[0])
 		error.Check(err)
-		//fmt.Print(string(dat))
 
 		key := "this_must_be_of_32_byte_length!!"
 		encryptedString := cipher.EncryptFile(key, string(dat))
 
-		// Storing encrypted text in new file
-		filePath := "/Users/luka/Desktop/encrypted/dat2"
-		f, err := os.Create(filePath)
+		f, err := os.Create(outputPath)
 		error.Check(err)
 
 		defer f.Close()
 
 		bytes, err := f.WriteString(encryptedString)
 		error.Check(err)
-		fmt.Printf("Wrote %d bytes to %s.\n", bytes, filePath)
+		fmt.Printf("Wrote %d bytes to %s.\n", bytes, outputPath)
 
 		f.Sync()
-
-		// Open file for I/O operations
-		// f, err := os.Open(args[0])
-		// check(err)
-
-		// Close file for I/O
-		// f.Close()
 	},
 }
 
 func init() {
+	// Required command flags
+	encryptCmd.Flags().StringP("path", "p", "", "File path to store the encryption result.")
+	_ = encryptCmd.MarkFlagRequired("path")
+
 	rootCmd.AddCommand(encryptCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// encryptCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// encryptCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/error/check.go
+++ b/error/check.go
@@ -1,8 +1,12 @@
 package error
 
+import (
+	"log"
+)
+
 // Displays error if it exists
 func Check(err error) {
 	if err != nil {
-		panic(err)
+		log.Fatalf("An Error occured\n%v", err)
 	}
 }

--- a/secret.txt
+++ b/secret.txt
@@ -1,0 +1,1 @@
+This is a secret that I want encrypted.


### PR DESCRIPTION
The flag command is currently working for the `encrypt` command. The flag `--path` is now required for the command to run and execute. The result of the encryption from the command argument path will now be stored in the command flag path. The flag path must be the full path to the file on one's system.

For example:
`go build`
`crypto encrypt names.txt --path=/Users/luka/Desktop/encrypted/names-hidden`